### PR TITLE
Fixed a judgment condition of existing window in TransitionMode.NewOrActive.

### DIFF
--- a/.NET4.0/Livet(.NET4.0)/Behaviors/Messaging/TransitionInteractionMessageAction.cs
+++ b/.NET4.0/Livet(.NET4.0)/Behaviors/Messaging/TransitionInteractionMessageAction.cs
@@ -123,7 +123,7 @@ namespace Livet.Behaviors.Messaging
                 case TransitionMode.NewOrActive:
                     var window = Application.Current.Windows
                         .OfType<Window>()
-                        .FirstOrDefault(w => w.GetType() == WindowType);
+                        .FirstOrDefault(w => w.GetType() == targetType);
 
                     if (window == null)
                     {


### PR DESCRIPTION
TransitionMode.NewOrActive において、既存ウィンドウかどうかを TransitionInteractionMessageAction.WindowType で判定すると、TransitionMessage.WindowType で指定したウィンドウは常に新規ウィンドウと判断されてしまいます。