### PR TITLE
Add null check

### DIFF
--- a/.NET4.0/Livet(.NET4.0)/LivetCompositeDisposable.cs
+++ b/.NET4.0/Livet(.NET4.0)/LivetCompositeDisposable.cs
@@ -59,6 +59,8 @@ namespace Livet
         /// <param name="item">追加するオブジェクト</param>
         public void Add(IDisposable item)
         {
+            if (item == null) throw new ArgumentNullException("item");
+
             ThrowExceptionIfDisposed();
             lock (_lockObject)
             {
@@ -87,6 +89,8 @@ namespace Livet
         /// <param name="item">追加するオブジェクト</param>
         public void AddFirst(IDisposable item)
         {
+            if (item == null) throw new ArgumentNullException("item");
+
             ThrowExceptionIfDisposed();
             lock (_lockObject)
             {
@@ -128,6 +132,8 @@ namespace Livet
         /// <returns>このコレクションに含まれているかどうか</returns>
         public bool Contains(IDisposable item)
         {
+            if (item == null) throw new ArgumentNullException("item");
+
             ThrowExceptionIfDisposed();
             lock (_lockObject)
             {
@@ -184,6 +190,8 @@ namespace Livet
         /// <returns>削除できたかどうか</returns>
         public bool Remove(IDisposable item)
         {
+            if (item == null) throw new ArgumentNullException("item");
+
             ThrowExceptionIfDisposed();
 
             lock (_lockObject)


### PR DESCRIPTION
以下のメソッドに引数のオブジェクトのnullチェックするようにしました。

* Add()
* AddFirst()
* Contains()
* Remove()

観点：
```
void Dispose(bool disposing)
```
の実装で、```_targetLists``` に追加されるオブジェクトは非nullであることを期待しているため。