### PR TITLE
Fixed NRE when drive root FolderSelectionMessage

### DIFF
--- a/.NET4.0/Livet.Extensions(.NET4.0)/Dialogs/CommonOpenFileFolderSelectionDialog.cs
+++ b/.NET4.0/Livet.Extensions(.NET4.0)/Dialogs/CommonOpenFileFolderSelectionDialog.cs
@@ -63,7 +63,8 @@ namespace Livet.Dialogs
 				{
 					// Set parent.
 					this._commonOpenFileDialog.DefaultFileName = asDirectory.Name;
-					this._commonOpenFileDialog.InitialDirectory = asDirectory.Parent.FullName;
+					this._commonOpenFileDialog.InitialDirectory = asDirectory.Parent?.FullName
+																?? "::{20D04FE0-3AEA-1069-A2D8-08002B30309D}";	// Set "My Computer", if drive root
 				}
 			}
 		}


### PR DESCRIPTION
`C:\\` 等ドライブのルートディレクトリを `SelectedPath` に設定した `FolderSelectionMessage` を `FolderBrowserDialogInteractionMessageAction` に投げると `NullReferenceException` が発生する問題を修正しました。

### 原因

`InitialDirectory` には `SelectedPath` の親ディレクトリを設定する仕様ですが、ルートディレクトリの場合親が `null` であるため、`NullReferenceException` が発生します。

### 修正内容

`SelectedPath` にルートディレクトリが選択されている場合、`InitialDirectory` には My Computer (Win10 では This PC) が設定されるよう変更しました。
