### PR TITLE
Visual Studio拡張を最新のVS2019でインストール出来るように変更

### DIFF
--- a/Templates/Livet.Extensibility/source.extension.vsixmanifest
+++ b/Templates/Livet.Extensibility/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Livet.Extensibility.084f01b5-62d7-4528-8c21-e58fe0e6ba24" Version="2.2.1" Language="ja-JP" Publisher="Kazuki Ohta" />
+        <Identity Id="Livet.Extensibility.084f01b5-62d7-4528-8c21-e58fe0e6ba24" Version="2.2.2" Language="ja-JP" Publisher="Kazuki Ohta" />
         <DisplayName>Livet プロジェクトテンプレート・アイテムテンプレート・コードスニペット拡張機能</DisplayName>
         <Description xml:space="preserve">Provide a project template, item templates and code snippets for development WPF app using Livet and C#.</Description>
         <MoreInfo>https://github.com/ugaya40/Livet</MoreInfo>
@@ -11,7 +11,7 @@
         <Tags>WPF, MVVM, Livet</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0, 16.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0, 16.1)" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
@@ -28,6 +28,6 @@
         <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="Livet.ProjectTemplate.CSharp.NETCore" d:TargetPath="|Livet.ProjectTemplate.CSharp.NETCore;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
     </Assets>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.1)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
いつもLivetにはお世話になっております。
最新のVisual Studio2019でLivetの拡張機能がインストール出来なかったので数行の変更ではありますがプルリクエストをお送りします。

よろしくお願いいたします。