### PR TITLE
Harmless refactorings

### DIFF
--- a/Livet.Extensions.Shared/Behaviors/Messaging/IO/FolderBrowserDialogInteractionMessageAction.cs
+++ b/Livet.Extensions.Shared/Behaviors/Messaging/IO/FolderBrowserDialogInteractionMessageAction.cs
@@ -36,15 +36,10 @@ namespace Livet.Behaviors.Messaging.IO
 					dialog.Description = folderSelectionMessage.Description;
 					dialog.SelectedPath = folderSelectionMessage.SelectedPath;
 
-                    if (dialog.ShowDialog(hostWindow).GetValueOrDefault())
-                    {
-                        folderSelectionMessage.Response = dialog.SelectedPath;
-                    }
-                    else
-                    {
-                        folderSelectionMessage.Response = null;
-                    }
-				}
+                    folderSelectionMessage.Response = dialog.ShowDialog(hostWindow).GetValueOrDefault()
+                        ? dialog.SelectedPath
+                        : null;
+                }
 			}
 		}
 	}

--- a/Livet.Extensions.Shared/Behaviors/Messaging/IO/FolderBrowserDialogInteractionMessageAction.cs
+++ b/Livet.Extensions.Shared/Behaviors/Messaging/IO/FolderBrowserDialogInteractionMessageAction.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Windows;
+﻿using System.Windows;
 using Livet.Dialogs;
 using Livet.Messaging;
 using Livet.Messaging.IO;

--- a/Livet.Extensions.Shared/Behaviors/Messaging/IO/FolderBrowserDialogInteractionMessageAction.cs
+++ b/Livet.Extensions.Shared/Behaviors/Messaging/IO/FolderBrowserDialogInteractionMessageAction.cs
@@ -18,9 +18,7 @@ namespace Livet.Behaviors.Messaging.IO
 		/// <param name="m"><see cref="FolderSelectionMessage"/> specified to <see cref="InteractionMessenger"/> in the client.</param>
 		protected override void InvokeAction( InteractionMessage m )
 		{
-			var folderSelectionMessage = m as FolderSelectionMessage;
-
-			if ( folderSelectionMessage != null )
+            if ( m is FolderSelectionMessage folderSelectionMessage )
 			{
                 Window hostWindow = Window.GetWindow(AssociatedObject);
 				if ( hostWindow == null )

--- a/Livet.Extensions.Shared/Dialogs/CommonOpenFileFolderSelectionDialog.cs
+++ b/Livet.Extensions.Shared/Dialogs/CommonOpenFileFolderSelectionDialog.cs
@@ -23,8 +23,8 @@ namespace Livet.Dialogs
 		/// </value>
 		public override string Title
 		{
-			get { return this._commonOpenFileDialog.Title; }
-			set { this._commonOpenFileDialog.Title = String.IsNullOrEmpty( value ) ? this._defaultTitle : value; }
+			get { return _commonOpenFileDialog.Title; }
+			set { _commonOpenFileDialog.Title = String.IsNullOrEmpty( value ) ? _defaultTitle : value; }
 		}
 
 		/// <summary>
@@ -45,7 +45,7 @@ namespace Livet.Dialogs
 		/// </value>
 		public override string SelectedPath
 		{
-			get { return this._commonOpenFileDialog.FileName; }
+			get { return _commonOpenFileDialog.FileName; }
 			set
 			{
 				DirectoryInfo asDirectory = null;
@@ -57,13 +57,13 @@ namespace Livet.Dialogs
 
 				if ( asDirectory == null )
 				{
-					this._commonOpenFileDialog.DefaultFileName = value;
+					_commonOpenFileDialog.DefaultFileName = value;
 				}
 				else
 				{
 					// Set parent.
-					this._commonOpenFileDialog.DefaultFileName = asDirectory.Name;
-					this._commonOpenFileDialog.InitialDirectory = asDirectory.Parent?.FullName
+					_commonOpenFileDialog.DefaultFileName = asDirectory.Name;
+					_commonOpenFileDialog.InitialDirectory = asDirectory.Parent?.FullName
 																?? "::{20D04FE0-3AEA-1069-A2D8-08002B30309D}";	// Set "My Computer", if drive root
 				}
 			}
@@ -74,13 +74,13 @@ namespace Livet.Dialogs
 		/// </summary>
 		public CommonOpenFileFolderSelectionDialog()
 		{
-			this._commonOpenFileDialog =
+			_commonOpenFileDialog =
 				new CommonOpenFileDialog()
 				{
 					IsFolderPicker = true,
 					Multiselect = false,
 				};
-			this._defaultTitle = this._commonOpenFileDialog.Title;
+			_defaultTitle = _commonOpenFileDialog.Title;
 		}
 
 		/// <summary>
@@ -91,7 +91,7 @@ namespace Livet.Dialogs
 		{
 			if ( disposing )
 			{
-				this._commonOpenFileDialog.Dispose();
+				_commonOpenFileDialog.Dispose();
 			}
 			base.Dispose( disposing );
 		}
@@ -105,7 +105,7 @@ namespace Livet.Dialogs
 		/// </returns>
 		protected override bool? ShowDialogCore( Window hostWindow )
 		{
-			switch ( this._commonOpenFileDialog.ShowDialog( hostWindow ) )
+			switch ( _commonOpenFileDialog.ShowDialog( hostWindow ) )
 			{
 				case CommonFileDialogResult.Ok:
 				{

--- a/Livet.Extensions.Shared/Dialogs/CommonOpenFileFolderSelectionDialog.cs
+++ b/Livet.Extensions.Shared/Dialogs/CommonOpenFileFolderSelectionDialog.cs
@@ -21,7 +21,7 @@ namespace Livet.Dialogs
 		///		Some dialog cannot support this value.
 		///		The <c>null</c> or empty indicates using default title.
 		/// </value>
-		public sealed override string Title
+		public override string Title
 		{
 			get { return this._commonOpenFileDialog.Title; }
 			set { this._commonOpenFileDialog.Title = String.IsNullOrEmpty( value ) ? this._defaultTitle : value; }
@@ -31,7 +31,7 @@ namespace Livet.Dialogs
 		///		This property is not supported.
 		/// </summary>
 		/// <value>Always <see cref="F:String.Empty"/>.</value>
-		public sealed override string Description
+		public override string Description
 		{
 			get { return String.Empty; }
 			set { }
@@ -43,7 +43,7 @@ namespace Livet.Dialogs
 		/// <value>
 		/// The selected path. This will be default path when the dialog is opened.
 		/// </value>
-		public sealed override string SelectedPath
+		public override string SelectedPath
 		{
 			get { return this._commonOpenFileDialog.FileName; }
 			set
@@ -87,7 +87,7 @@ namespace Livet.Dialogs
 		/// Releases unmanaged and - optionally - managed resources
 		/// </summary>
 		/// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
-		protected sealed override void Dispose( bool disposing )
+		protected override void Dispose( bool disposing )
 		{
 			if ( disposing )
 			{
@@ -103,7 +103,7 @@ namespace Livet.Dialogs
 		/// <returns>
 		/// The result of the dialog.
 		/// </returns>
-		protected sealed override bool? ShowDialogCore( Window hostWindow )
+		protected override bool? ShowDialogCore( Window hostWindow )
 		{
 			switch ( this._commonOpenFileDialog.ShowDialog( hostWindow ) )
 			{

--- a/Livet.Extensions.Shared/Dialogs/FolderBrowserFolderSelectionDialog.cs
+++ b/Livet.Extensions.Shared/Dialogs/FolderBrowserFolderSelectionDialog.cs
@@ -21,8 +21,8 @@ namespace Livet.Dialogs
 		/// </value>
 		public override string Description
 		{
-			get { return this._folderBrowserDialog.Description; }
-			set { this._folderBrowserDialog.Description = value; }
+			get { return _folderBrowserDialog.Description; }
+			set { _folderBrowserDialog.Description = value; }
 		}
 
 		/// <summary>
@@ -33,17 +33,17 @@ namespace Livet.Dialogs
 		/// </value>
 		public override string SelectedPath
 		{
-			get { return this._folderBrowserDialog.SelectedPath; }
+			get { return _folderBrowserDialog.SelectedPath; }
 			set
 			{
 				// FolderBrowserDialog.SelectedPath must ends with Path.DirectorySeparatorChar.
 				if ( value != null && value.LastOrDefault() != Path.DirectorySeparatorChar )
 				{
-					this._folderBrowserDialog.SelectedPath = value + Path.DirectorySeparatorChar;
+					_folderBrowserDialog.SelectedPath = value + Path.DirectorySeparatorChar;
 				}
 				else
 				{
-					this._folderBrowserDialog.SelectedPath = value;
+					_folderBrowserDialog.SelectedPath = value;
 				}
 			}
 		}
@@ -63,7 +63,7 @@ namespace Livet.Dialogs
 		/// </summary>
 		public FolderBrowserFolderSelectionDialog()
 		{
-			this._folderBrowserDialog =
+			_folderBrowserDialog =
 				new System.Windows.Forms.FolderBrowserDialog()
 				{
 					ShowNewFolderButton = true,
@@ -79,7 +79,7 @@ namespace Livet.Dialogs
 		{
 			if ( disposing )
 			{
-				this._folderBrowserDialog.Dispose();
+				_folderBrowserDialog.Dispose();
 			}
 
 			base.Dispose( disposing );
@@ -94,7 +94,7 @@ namespace Livet.Dialogs
 		/// </returns>
 		protected override bool? ShowDialogCore( Window hostWindow )
 		{
-			switch ( this._folderBrowserDialog.ShowDialog( new WindowsFormsWin32Window( new WindowInteropHelper( hostWindow ).EnsureHandle() ) ) )
+			switch ( _folderBrowserDialog.ShowDialog( new WindowsFormsWin32Window( new WindowInteropHelper( hostWindow ).EnsureHandle() ) ) )
 			{
 				case System.Windows.Forms.DialogResult.OK:
 				case System.Windows.Forms.DialogResult.Yes:
@@ -123,7 +123,7 @@ namespace Livet.Dialogs
 			///	</returns>
 			public IntPtr Handle
 			{
-				get { return this._handle; }
+				get { return _handle; }
 			}
 
 			/// <summary>
@@ -132,7 +132,7 @@ namespace Livet.Dialogs
 			/// <param name="hwnd">The HWND.</param>
 			public WindowsFormsWin32Window( IntPtr hwnd )
 			{
-				this._handle = hwnd;
+				_handle = hwnd;
 			}
 		}
 	}

--- a/Livet.Extensions.Shared/Dialogs/FolderBrowserFolderSelectionDialog.cs
+++ b/Livet.Extensions.Shared/Dialogs/FolderBrowserFolderSelectionDialog.cs
@@ -19,7 +19,7 @@ namespace Livet.Dialogs
 		/// <value>
 		/// The descriptive text to instruct the operation.
 		/// </value>
-		public sealed override string Description
+		public override string Description
 		{
 			get { return this._folderBrowserDialog.Description; }
 			set { this._folderBrowserDialog.Description = value; }
@@ -31,7 +31,7 @@ namespace Livet.Dialogs
 		/// <value>
 		/// The selected path. This will be default path when the dialog is opened.
 		/// </value>
-		public sealed override string SelectedPath
+		public override string SelectedPath
 		{
 			get { return this._folderBrowserDialog.SelectedPath; }
 			set
@@ -52,7 +52,7 @@ namespace Livet.Dialogs
 		///		This property is not supported.
 		/// </summary>
 		/// <value>Always <see cref="F:String.Empty"/>.</value>
-		public sealed override string Title
+		public override string Title
 		{
 			get { return String.Empty; }
 			set { }
@@ -75,7 +75,7 @@ namespace Livet.Dialogs
 		/// Releases unmanaged and - optionally - managed resources
 		/// </summary>
 		/// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
-		protected sealed override void Dispose( bool disposing )
+		protected override void Dispose( bool disposing )
 		{
 			if ( disposing )
 			{
@@ -92,7 +92,7 @@ namespace Livet.Dialogs
 		/// <returns>
 		/// The result of the dialog.
 		/// </returns>
-		protected sealed override bool? ShowDialogCore( Window hostWindow )
+		protected override bool? ShowDialogCore( Window hostWindow )
 		{
 			switch ( this._folderBrowserDialog.ShowDialog( new WindowsFormsWin32Window( new WindowInteropHelper( hostWindow ).EnsureHandle() ) ) )
 			{

--- a/Livet.Extensions.Shared/Dialogs/FolderSelectionDialog.cs
+++ b/Livet.Extensions.Shared/Dialogs/FolderSelectionDialog.cs
@@ -46,7 +46,7 @@ namespace Livet.Dialogs
 		/// </summary>
 		public void Dispose()
 		{
-			this.Dispose( true );
+			Dispose( true );
 			GC.SuppressFinalize( this );
 		}
 
@@ -75,7 +75,7 @@ namespace Livet.Dialogs
 				throw new ArgumentNullException( nameof(hostWindow) );
 			}
 
-			return this.ShowDialogCore( hostWindow );
+			return ShowDialogCore( hostWindow );
 		}
 
 		/// <summary>

--- a/Livet.Extensions.Shared/Dialogs/FolderSelectionDialog.cs
+++ b/Livet.Extensions.Shared/Dialogs/FolderSelectionDialog.cs
@@ -72,7 +72,7 @@ namespace Livet.Dialogs
 		{
 			if ( hostWindow == null )
 			{
-				throw new ArgumentNullException( "hostWindow" );
+				throw new ArgumentNullException( nameof(hostWindow) );
 			}
 
 			return this.ShowDialogCore( hostWindow );

--- a/Livet.Extensions.Shared/Dialogs/FolderSelectionDialogFactory.cs
+++ b/Livet.Extensions.Shared/Dialogs/FolderSelectionDialogFactory.cs
@@ -64,7 +64,7 @@ namespace Livet.Dialogs
 				{
 					throw new ArgumentException(
 						String.Format( CultureInfo.CurrentCulture, Resources.UnsupportedEnumValue, typeof( FolderSelectionDialogPreference ), preference, ( int )preference ),
-						"preference"
+						nameof(preference)
 					);
 				}
 			}

--- a/Livet.Extensions.Shared/Messaging/IO/FolderSelectionMessage.cs
+++ b/Livet.Extensions.Shared/Messaging/IO/FolderSelectionMessage.cs
@@ -40,7 +40,7 @@ namespace Livet.Messaging.IO
 		///		Creates the new instance of this class.
 		/// </summary>
 		/// <returns>The new <see cref="FolderSelectionMessage"/> which has identical properties to this instance.</returns>
-		protected sealed override Freezable CreateInstanceCore()
+		protected override Freezable CreateInstanceCore()
 		{
 			return new FolderSelectionMessage( this.MessageKey );
 		}

--- a/Livet.Extensions.Shared/Messaging/IO/FolderSelectionMessage.cs
+++ b/Livet.Extensions.Shared/Messaging/IO/FolderSelectionMessage.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Windows;
-using Livet.Messaging;
 
 namespace Livet.Messaging.IO
 {

--- a/Livet.Extensions.Shared/Messaging/IO/FolderSelectionMessage.cs
+++ b/Livet.Extensions.Shared/Messaging/IO/FolderSelectionMessage.cs
@@ -42,7 +42,7 @@ namespace Livet.Messaging.IO
 		/// <returns>The new <see cref="FolderSelectionMessage"/> which has identical properties to this instance.</returns>
 		protected override Freezable CreateInstanceCore()
 		{
-			return new FolderSelectionMessage( this.MessageKey );
+			return new FolderSelectionMessage( MessageKey );
 		}
 
 		/// <summary>

--- a/Livet.Shared/Behaviors/DataContextDisposeAction.cs
+++ b/Livet.Shared/Behaviors/DataContextDisposeAction.cs
@@ -13,10 +13,7 @@ namespace Livet.Behaviors
         {
             var disposable = AssociatedObject.DataContext as IDisposable;
 
-            if (disposable != null)
-            {
-                disposable.Dispose();
-            }
+            disposable?.Dispose();
         }
     }
 }

--- a/Livet.Shared/Behaviors/Messaging/ConfirmationDialogInteractionMessageAction.cs
+++ b/Livet.Shared/Behaviors/Messaging/ConfirmationDialogInteractionMessageAction.cs
@@ -10,9 +10,7 @@ namespace Livet.Behaviors.Messaging
     {
         protected override void InvokeAction(InteractionMessage message)
         {
-            var confirmMessage = message as ConfirmationMessage;
-
-            if (confirmMessage != null)
+            if (message is ConfirmationMessage confirmMessage)
             {
                 var result = MessageBox.Show(
                     confirmMessage.Text,

--- a/Livet.Shared/Behaviors/Messaging/IO/OpenFileDialogInteractionMessageAction.cs
+++ b/Livet.Shared/Behaviors/Messaging/IO/OpenFileDialogInteractionMessageAction.cs
@@ -13,9 +13,7 @@ namespace Livet.Behaviors.Messaging.IO
     {
         protected override void InvokeAction(InteractionMessage message)
         {
-            var openFileMessage = message as OpeningFileSelectionMessage;
-
-            if (openFileMessage != null)
+            if (message is OpeningFileSelectionMessage openFileMessage)
             {
                 var dialog = new OpenFileDialog
                                  {

--- a/Livet.Shared/Behaviors/Messaging/IO/SaveFileDialogInteractionMessageAction.cs
+++ b/Livet.Shared/Behaviors/Messaging/IO/SaveFileDialogInteractionMessageAction.cs
@@ -13,9 +13,7 @@ namespace Livet.Behaviors.Messaging.IO
     {
         protected override void InvokeAction(InteractionMessage message)
         {
-            var saveFileMessage = message as SavingFileSelectionMessage;
-
-            if (saveFileMessage != null)
+            if (message is SavingFileSelectionMessage saveFileMessage)
             {
                 var dialog = new SaveFileDialog
                                             {

--- a/Livet.Shared/Behaviors/Messaging/InformationDialogInteractionMessageAction.cs
+++ b/Livet.Shared/Behaviors/Messaging/InformationDialogInteractionMessageAction.cs
@@ -10,9 +10,7 @@ namespace Livet.Behaviors.Messaging
     {
         protected override void InvokeAction(InteractionMessage message)
         {
-            var informationMessage = message as InformationMessage;
-
-            if (informationMessage != null)
+            if (message is InformationMessage informationMessage)
             {
                 MessageBox.Show(
                     informationMessage.Text,

--- a/Livet.Shared/Behaviors/Messaging/InteractionMessageAction.cs
+++ b/Livet.Shared/Behaviors/Messaging/InteractionMessageAction.cs
@@ -39,10 +39,7 @@ namespace Livet.Behaviors.Messaging
             {
                 InvokeAction(message);
 
-                if (DirectInteractionMessage != null)
-                {
-                    DirectInteractionMessage.InvokeCallbacks(message);
-                }
+                DirectInteractionMessage?.InvokeCallbacks(message);
             }
 
         }

--- a/Livet.Shared/Behaviors/Messaging/InteractionMessageTrigger.cs
+++ b/Livet.Shared/Behaviors/Messaging/InteractionMessageTrigger.cs
@@ -81,10 +81,7 @@ namespace Livet.Behaviors.Messaging
 
             if (e.OldValue != null)
             {
-                if (thisReference._listener != null)
-                {
-                    thisReference._listener.Dispose();
-                }
+                thisReference._listener?.Dispose();
             }
 
             if (e.NewValue != null && thisReference != null)
@@ -174,9 +171,9 @@ namespace Livet.Behaviors.Messaging
 
         protected override void OnDetaching()
         {
-            if (Messenger != null && _listener != null)
+            if (Messenger != null)
             {
-                _listener.Dispose();
+                _listener?.Dispose();
             }
 
             if (AssociatedObject != null)

--- a/Livet.Shared/Behaviors/Messaging/TransitionInteractionMessageAction.cs
+++ b/Livet.Shared/Behaviors/Messaging/TransitionInteractionMessageAction.cs
@@ -71,14 +71,7 @@ namespace Livet.Behaviors.Messaging
 
             Type targetType;
 
-            if (transitionMessage.WindowType != null)
-            {
-                targetType = transitionMessage.WindowType;
-            }
-            else
-            {
-                targetType = WindowType;
-            }
+            targetType = transitionMessage.WindowType != null ? transitionMessage.WindowType : WindowType;
 
             if (!IsValidWindowType(targetType))
             {

--- a/Livet.Shared/Behaviors/Messaging/TransitionInteractionMessageAction.cs
+++ b/Livet.Shared/Behaviors/Messaging/TransitionInteractionMessageAction.cs
@@ -69,9 +69,7 @@ namespace Livet.Behaviors.Messaging
 
             if (transitionMessage == null) return;
 
-            Type targetType;
-
-            targetType = transitionMessage.WindowType != null ? transitionMessage.WindowType : WindowType;
+            var targetType = transitionMessage.WindowType != null ? transitionMessage.WindowType : WindowType;
 
             if (!IsValidWindowType(targetType))
             {

--- a/Livet.Shared/Behaviors/Messaging/Windows/WindowInteractionMessageAction.cs
+++ b/Livet.Shared/Behaviors/Messaging/Windows/WindowInteractionMessageAction.cs
@@ -11,9 +11,7 @@ namespace Livet.Behaviors.Messaging.Windows
     {
         protected override void InvokeAction(InteractionMessage message)
         {
-            var windowMessage = message as WindowActionMessage;
-
-            if (windowMessage != null)
+            if (message is WindowActionMessage windowMessage)
             {
                 var window = Window.GetWindow(AssociatedObject);
 

--- a/Livet.Shared/Behaviors/MethodBinder.cs
+++ b/Livet.Shared/Behaviors/MethodBinder.cs
@@ -24,8 +24,8 @@ namespace Livet.Behaviors
 
         public void Invoke(object targetObject, string methodName)
         {
-            if (targetObject == null) throw new ArgumentNullException("targetObject");
-            if (methodName == null) throw new ArgumentNullException("methodName");
+            if (targetObject == null) throw new ArgumentNullException(nameof(targetObject));
+            if (methodName == null) throw new ArgumentNullException(nameof(methodName));
 
             var newTargetObjectType = targetObject.GetType();
 

--- a/Livet.Shared/Behaviors/MethodBinderWithArgument.cs
+++ b/Livet.Shared/Behaviors/MethodBinderWithArgument.cs
@@ -25,8 +25,8 @@ namespace Livet.Behaviors
 
         public void Invoke(object targetObject, string methodName,object argument)
         {
-            if (targetObject == null) throw new ArgumentNullException("targetObject");
-            if (methodName == null) throw new ArgumentNullException("methodName");
+            if (targetObject == null) throw new ArgumentNullException(nameof(targetObject));
+            if (methodName == null) throw new ArgumentNullException(nameof(methodName));
 
             var newTargetObjectType = targetObject.GetType();
             var newArgumentType = argument.GetType();

--- a/Livet.Shared/Commands/ListenerCommand.cs
+++ b/Livet.Shared/Commands/ListenerCommand.cs
@@ -75,10 +75,7 @@ namespace Livet.Commands
         private void OnPropertyChanged()
         {
             var handler = Interlocked.CompareExchange(ref PropertyChanged, null, null);
-            if (handler != null)
-            {
-                handler(this,EventArgsFactory.GetPropertyChangedEventArgs("CanExecute"));
-            }
+            handler?.Invoke(this,EventArgsFactory.GetPropertyChangedEventArgs("CanExecute"));
         }
 
         /// <summary>

--- a/Livet.Shared/Commands/ListenerCommand.cs
+++ b/Livet.Shared/Commands/ListenerCommand.cs
@@ -36,7 +36,7 @@ namespace Livet.Commands
         /// </summary>
         public bool CanExecute
         {
-            get { return _canExecute == null ? true : _canExecute(); }
+            get { return _canExecute == null || _canExecute(); }
         }
 
         /// <summary>

--- a/Livet.Shared/Commands/ListenerCommand.cs
+++ b/Livet.Shared/Commands/ListenerCommand.cs
@@ -27,9 +27,7 @@ namespace Livet.Commands
         /// <param name="canExecute">コマンドが実行可能かどうかをあらわすFunc&lt;bool&gt;</param>
         public ListenerCommand(Action<T> execute, Func<bool> canExecute)
         {
-            if (execute == null) throw new ArgumentNullException(nameof(execute));
-
-            _execute = execute;
+            _execute = execute ?? throw new ArgumentNullException(nameof(execute));
             _canExecute = canExecute;
         }
 

--- a/Livet.Shared/Commands/ListenerCommand.cs
+++ b/Livet.Shared/Commands/ListenerCommand.cs
@@ -27,7 +27,7 @@ namespace Livet.Commands
         /// <param name="canExecute">コマンドが実行可能かどうかをあらわすFunc&lt;bool&gt;</param>
         public ListenerCommand(Action<T> execute, Func<bool> canExecute)
         {
-            if (execute == null) throw new ArgumentNullException("execute");
+            if (execute == null) throw new ArgumentNullException(nameof(execute));
 
             _execute = execute;
             _canExecute = canExecute;

--- a/Livet.Shared/Commands/ViewModelCommand.cs
+++ b/Livet.Shared/Commands/ViewModelCommand.cs
@@ -26,7 +26,7 @@ namespace Livet.Commands
         /// <param name="canExecute">コマンドが実行可能かどうかをあらわすFunc&lt;bool&gt;</param>
         public ViewModelCommand(Action execute, Func<bool> canExecute)
         {
-            if (execute == null) throw new ArgumentNullException("execute");
+            if (execute == null) throw new ArgumentNullException(nameof(execute));
             _execute = execute;
             _canExecute = canExecute;
         }

--- a/Livet.Shared/Commands/ViewModelCommand.cs
+++ b/Livet.Shared/Commands/ViewModelCommand.cs
@@ -26,8 +26,7 @@ namespace Livet.Commands
         /// <param name="canExecute">コマンドが実行可能かどうかをあらわすFunc&lt;bool&gt;</param>
         public ViewModelCommand(Action execute, Func<bool> canExecute)
         {
-            if (execute == null) throw new ArgumentNullException(nameof(execute));
-            _execute = execute;
+            _execute = execute ?? throw new ArgumentNullException(nameof(execute));
             _canExecute = canExecute;
         }
 

--- a/Livet.Shared/Commands/ViewModelCommand.cs
+++ b/Livet.Shared/Commands/ViewModelCommand.cs
@@ -35,7 +35,7 @@ namespace Livet.Commands
         /// </summary>
         public bool CanExecute
         {
-            get { return _canExecute == null ? true : _canExecute(); }
+            get { return _canExecute?.Invoke() ?? true; }
         }
 
         /// <summary>

--- a/Livet.Shared/DispatcherCollection.cs
+++ b/Livet.Shared/DispatcherCollection.cs
@@ -203,9 +203,7 @@ namespace Livet
         /// <param name="newIndex">移動先のインデックス</param>
         public void Move(int oldIndex, int newIndex)
         {
-            var sourceAsObservableCollection = _sourceAsIList as ObservableCollection<T>;
-
-            if (sourceAsObservableCollection != null)
+            if (_sourceAsIList is ObservableCollection<T> sourceAsObservableCollection)
             {
                 sourceAsObservableCollection.Move(oldIndex, newIndex);
             }

--- a/Livet.Shared/DispatcherCollection.cs
+++ b/Livet.Shared/DispatcherCollection.cs
@@ -33,7 +33,6 @@ namespace Livet
         public DispatcherCollection(INotifyCollectionChanged collection, Dispatcher dispatcher)
         {
             if (collection == null) throw new ArgumentNullException(nameof(collection));
-            if (dispatcher == null) throw new ArgumentNullException(nameof(dispatcher));
 
             if (!(collection is IList<T>))
             {
@@ -47,7 +46,7 @@ namespace Livet
 
             _sourceAsIList = (IList<T>)collection;
 
-            Dispatcher = dispatcher;
+            Dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
             CollectionChangedDispatcherPriority = DispatcherPriority.Normal;
 
             ((INotifyPropertyChanged)collection).PropertyChanged += (sender, e) =>

--- a/Livet.Shared/DispatcherCollection.cs
+++ b/Livet.Shared/DispatcherCollection.cs
@@ -32,8 +32,8 @@ namespace Livet
         /// <param name="dispatcher">UIDispatcher(通常はDispatcherHelper.UIDispatcher)</param>
         public DispatcherCollection(INotifyCollectionChanged collection, Dispatcher dispatcher)
         {
-            if (collection == null) throw new ArgumentNullException("collection");
-            if (dispatcher == null) throw new ArgumentNullException("dispatcher");
+            if (collection == null) throw new ArgumentNullException(nameof(collection));
+            if (dispatcher == null) throw new ArgumentNullException(nameof(dispatcher));
 
             if (!(collection is IList<T>))
             {

--- a/Livet.Shared/DispatcherCollection.cs
+++ b/Livet.Shared/DispatcherCollection.cs
@@ -214,10 +214,7 @@ namespace Livet
             {
                 var sourceAsConcurrentObservableCollection = _sourceAsIList as ObservableSynchronizedCollection<T>;
 
-                if (sourceAsConcurrentObservableCollection != null)
-                {
-                    sourceAsConcurrentObservableCollection.Move(oldIndex, newIndex);
-                }
+                sourceAsConcurrentObservableCollection?.Move(oldIndex, newIndex);
             }
         }
 
@@ -272,20 +269,14 @@ namespace Livet
         {
             var threadSafeHandler = Interlocked.CompareExchange(ref CollectionChanged, null, null);
 
-            if (threadSafeHandler != null)
-            {
-                threadSafeHandler(this, args);
-            }
+            threadSafeHandler?.Invoke(this, args);
         }
 
         protected void OnPropertyChanged(string propertyName)
         {
             var threadSafeHandler = Interlocked.CompareExchange(ref PropertyChanged, null, null);
 
-            if (threadSafeHandler != null)
-            {
-                threadSafeHandler(this, EventArgsFactory.GetPropertyChangedEventArgs(propertyName));
-            }
+            threadSafeHandler?.Invoke(this, EventArgsFactory.GetPropertyChangedEventArgs(propertyName));
         }
 
         /// <summary>

--- a/Livet.Shared/EventListeners/AnonymousCollectionChangedEventHandlerBag.cs
+++ b/Livet.Shared/EventListeners/AnonymousCollectionChangedEventHandlerBag.cs
@@ -19,13 +19,13 @@ namespace Livet.EventListeners
 
         internal AnonymousCollectionChangedEventHandlerBag(INotifyCollectionChanged source)
         {
-            if (source == null) throw new ArgumentNullException("source");
+            if (source == null) throw new ArgumentNullException(nameof(source));
             _source = new WeakReference<INotifyCollectionChanged>(source);
         }
 
         internal AnonymousCollectionChangedEventHandlerBag(INotifyCollectionChanged source,NotifyCollectionChangedEventHandler handler) : this(source)
         {
-            if (handler == null) throw new ArgumentNullException("handler");
+            if (handler == null) throw new ArgumentNullException(nameof(handler));
             RegisterHandler(handler);
         }
 

--- a/Livet.Shared/EventListeners/AnonymousCollectionChangedEventHandlerBag.cs
+++ b/Livet.Shared/EventListeners/AnonymousCollectionChangedEventHandlerBag.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
-using System.Text;
 
 namespace Livet.EventListeners
 {

--- a/Livet.Shared/EventListeners/AnonymousPropertyChangedEventHandlerBag.cs
+++ b/Livet.Shared/EventListeners/AnonymousPropertyChangedEventHandlerBag.cs
@@ -15,7 +15,7 @@ namespace Livet.EventListeners
 
         internal AnonymousPropertyChangedEventHandlerBag(INotifyPropertyChanged source)
         {
-            if (source == null) throw new ArgumentNullException("source");
+            if (source == null) throw new ArgumentNullException(nameof(source));
 
             _source = new WeakReference<INotifyPropertyChanged>(source);
         }
@@ -23,7 +23,7 @@ namespace Livet.EventListeners
         internal AnonymousPropertyChangedEventHandlerBag(INotifyPropertyChanged source, PropertyChangedEventHandler handler)
             : this(source)
         {
-            if (handler == null) throw new ArgumentNullException("handler");
+            if (handler == null) throw new ArgumentNullException(nameof(handler));
             RegisterHandler(handler);
         }
 
@@ -49,7 +49,7 @@ namespace Livet.EventListeners
 
         internal void RegisterHandler<T>(Expression<Func<T>> propertyExpression, PropertyChangedEventHandler handler)
         {
-            if (propertyExpression == null) throw new ArgumentNullException("propertyExpression");
+            if (propertyExpression == null) throw new ArgumentNullException(nameof(propertyExpression));
 
             if (!(propertyExpression.Body is MemberExpression)) throw new NotSupportedException("このメソッドでは ()=>プロパティ の形式のラムダ式以外許可されません");
 
@@ -133,7 +133,7 @@ namespace Livet.EventListeners
 
         internal void Add<T>(Expression<Func<T>> propertyExpression, PropertyChangedEventHandler handler)
         {
-            if (propertyExpression == null) throw new ArgumentNullException("propertyExpression");
+            if (propertyExpression == null) throw new ArgumentNullException(nameof(propertyExpression));
 
             if (!(propertyExpression.Body is MemberExpression)) throw new NotSupportedException("このメソッドでは ()=>プロパティ の形式のラムダ式以外許可されません");
 
@@ -145,7 +145,7 @@ namespace Livet.EventListeners
 
         internal void Add<T>(Expression<Func<T>> propertyExpression, params PropertyChangedEventHandler[] handlers)
         {
-            if (propertyExpression == null) throw new ArgumentNullException("propertyExpression");
+            if (propertyExpression == null) throw new ArgumentNullException(nameof(propertyExpression));
 
             if (!(propertyExpression.Body is MemberExpression)) throw new NotSupportedException("このメソッドでは ()=>プロパティ の形式のラムダ式以外許可されません");
 

--- a/Livet.Shared/EventListeners/AnonymousPropertyChangedEventHandlerBag.cs
+++ b/Livet.Shared/EventListeners/AnonymousPropertyChangedEventHandlerBag.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
 
 namespace Livet.EventListeners
 {

--- a/Livet.Shared/EventListeners/CollectionChangedEventListener.cs
+++ b/Livet.Shared/EventListeners/CollectionChangedEventListener.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Collections.Specialized;
-using System.Collections.Concurrent;
 
 namespace Livet.EventListeners
 {

--- a/Livet.Shared/EventListeners/EventListener.cs
+++ b/Livet.Shared/EventListeners/EventListener.cs
@@ -36,13 +36,9 @@ namespace Livet.EventListeners
         {
             if (_initialized) return;
 
-            if (add == null) throw new ArgumentNullException(nameof(add));
-            if (remove == null) throw new ArgumentNullException(nameof(remove));
-            if (handler == null) throw new ArgumentNullException(nameof(handler));
-
-            _add = add;
-            _handler = handler;
-            _remove = remove;
+            _add = add ?? throw new ArgumentNullException(nameof(add));
+            _handler = handler ?? throw new ArgumentNullException(nameof(handler));
+            _remove = remove ?? throw new ArgumentNullException(nameof(remove));
             add(handler);
         }
 

--- a/Livet.Shared/EventListeners/EventListener.cs
+++ b/Livet.Shared/EventListeners/EventListener.cs
@@ -36,9 +36,9 @@ namespace Livet.EventListeners
         {
             if (_initialized) return;
 
-            if (add == null) throw new ArgumentNullException("add");
-            if (remove == null) throw new ArgumentNullException("remove");
-            if (handler == null) throw new ArgumentNullException("handler");
+            if (add == null) throw new ArgumentNullException(nameof(add));
+            if (remove == null) throw new ArgumentNullException(nameof(remove));
+            if (handler == null) throw new ArgumentNullException(nameof(handler));
 
             _add = add;
             _handler = handler;

--- a/Livet.Shared/EventListeners/PropertyChangedEventListener.cs
+++ b/Livet.Shared/EventListeners/PropertyChangedEventListener.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Collections.Concurrent;
 using System.Linq.Expressions;
 
 namespace Livet.EventListeners

--- a/Livet.Shared/EventListeners/WeakEvents/CollectionChangedWeakEventListener.cs
+++ b/Livet.Shared/EventListeners/WeakEvents/CollectionChangedWeakEventListener.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Concurrent;
+﻿using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Linq;
-using System.Text;
 
 namespace Livet.EventListeners.WeakEvents
 {

--- a/Livet.Shared/EventListeners/WeakEvents/LivetWeakEventListener.cs
+++ b/Livet.Shared/EventListeners/WeakEvents/LivetWeakEventListener.cs
@@ -45,10 +45,10 @@ namespace Livet.EventListeners.WeakEvents
         {
             if (_initialized) return;
 
-            if (conversion == null) throw new ArgumentNullException("conversion");
-            if (add == null) throw new ArgumentNullException("add");
-            if (remove == null) throw new ArgumentNullException("remove");
-            if (handler == null) throw new ArgumentNullException("handler");
+            if (conversion == null) throw new ArgumentNullException(nameof(conversion));
+            if (add == null) throw new ArgumentNullException(nameof(add));
+            if (remove == null) throw new ArgumentNullException(nameof(remove));
+            if (handler == null) throw new ArgumentNullException(nameof(handler));
 
             _handler = handler;
             _remove = remove;

--- a/Livet.Shared/EventListeners/WeakEvents/LivetWeakEventListener.cs
+++ b/Livet.Shared/EventListeners/WeakEvents/LivetWeakEventListener.cs
@@ -44,11 +44,9 @@ namespace Livet.EventListeners.WeakEvents
 
             if (conversion == null) throw new ArgumentNullException(nameof(conversion));
             if (add == null) throw new ArgumentNullException(nameof(add));
-            if (remove == null) throw new ArgumentNullException(nameof(remove));
-            if (handler == null) throw new ArgumentNullException(nameof(handler));
 
-            _handler = handler;
-            _remove = remove;
+            _handler = handler ?? throw new ArgumentNullException(nameof(handler));
+            _remove = remove ?? throw new ArgumentNullException(nameof(remove));
 
             _resultHandler = GetStaticHandler(new WeakReference<LivetWeakEventListener<THandler, TEventArgs>>(this), conversion);
 

--- a/Livet.Shared/EventListeners/WeakEvents/LivetWeakEventListener.cs
+++ b/Livet.Shared/EventListeners/WeakEvents/LivetWeakEventListener.cs
@@ -24,10 +24,7 @@ namespace Livet.EventListeners.WeakEvents
             {
                 var handler = listenerResult._handler;
 
-                if (handler != null)
-                {
-                    handler(sender, args);
-                }
+                handler?.Invoke(sender, args);
             }
         }
 

--- a/Livet.Shared/EventListeners/WeakEvents/PropertyChangedWeakEventListener.cs
+++ b/Livet.Shared/EventListeners/WeakEvents/PropertyChangedWeakEventListener.cs
@@ -1,11 +1,7 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
 
 namespace Livet.EventListeners.WeakEvents
 {

--- a/Livet.Shared/LivetCompositeDisposable.cs
+++ b/Livet.Shared/LivetCompositeDisposable.cs
@@ -26,7 +26,7 @@ namespace Livet
         /// <param name="sourceDisposableList">ソースとなるIDisposableコレクション</param>
         public LivetCompositeDisposable(IEnumerable<IDisposable> sourceDisposableList)
         {
-            if (sourceDisposableList == null) throw new ArgumentNullException("sourceDisposableList");
+            if (sourceDisposableList == null) throw new ArgumentNullException(nameof(sourceDisposableList));
 
             _targetLists = new List<IDisposable>(sourceDisposableList);
         }
@@ -59,7 +59,7 @@ namespace Livet
         /// <param name="item">追加するオブジェクト</param>
         public void Add(IDisposable item)
         {
-            if (item == null) throw new ArgumentNullException("item");
+            if (item == null) throw new ArgumentNullException(nameof(item));
 
             ThrowExceptionIfDisposed();
             lock (_lockObject)
@@ -89,7 +89,7 @@ namespace Livet
         /// <param name="item">追加するオブジェクト</param>
         public void AddFirst(IDisposable item)
         {
-            if (item == null) throw new ArgumentNullException("item");
+            if (item == null) throw new ArgumentNullException(nameof(item));
 
             ThrowExceptionIfDisposed();
             lock (_lockObject)
@@ -132,7 +132,7 @@ namespace Livet
         /// <returns>このコレクションに含まれているかどうか</returns>
         public bool Contains(IDisposable item)
         {
-            if (item == null) throw new ArgumentNullException("item");
+            if (item == null) throw new ArgumentNullException(nameof(item));
 
             ThrowExceptionIfDisposed();
             lock (_lockObject)
@@ -190,7 +190,7 @@ namespace Livet
         /// <returns>削除できたかどうか</returns>
         public bool Remove(IDisposable item)
         {
-            if (item == null) throw new ArgumentNullException("item");
+            if (item == null) throw new ArgumentNullException(nameof(item));
 
             ThrowExceptionIfDisposed();
 

--- a/Livet.Shared/Messaging/GenericInteractionMessage.cs
+++ b/Livet.Shared/Messaging/GenericInteractionMessage.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
+﻿using System.Windows;
 
 namespace Livet.Messaging
 {

--- a/Livet.Shared/Messaging/GenericResponsiveInteractionMessage.cs
+++ b/Livet.Shared/Messaging/GenericResponsiveInteractionMessage.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
+﻿using System.Windows;
 
 namespace Livet.Messaging
 {

--- a/Livet.Shared/Messaging/InteractionMessenger.cs
+++ b/Livet.Shared/Messaging/InteractionMessenger.cs
@@ -131,10 +131,7 @@ namespace Livet.Messaging
             }
 
             var msg = await Task<T>.Factory.StartNew(() => GetResponse(message));
-            if (callback != null)
-            {
-                callback(msg);
-            }
+            callback?.Invoke(msg);
             return msg;
         }
     }

--- a/Livet.Shared/Messaging/MessageListener.cs
+++ b/Livet.Shared/Messaging/MessageListener.cs
@@ -3,8 +3,6 @@ using System.Windows.Threading;
 using Livet.EventListeners.WeakEvents;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Livet.Messaging
 {

--- a/Livet.Shared/Messaging/TransitionMessage.cs
+++ b/Livet.Shared/Messaging/TransitionMessage.cs
@@ -53,7 +53,7 @@ namespace Livet.Messaging
             {
                 if (!windowType.IsSubclassOf(typeof(Window)))
                 {
-                    throw new ArgumentException("Windowの派生クラスを指定してください。", "windowType");
+                    throw new ArgumentException("Windowの派生クラスを指定してください。", nameof(windowType));
                 }
             }
 

--- a/Livet.Shared/NotificationObject.cs
+++ b/Livet.Shared/NotificationObject.cs
@@ -30,7 +30,7 @@ namespace Livet
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
         protected virtual void RaisePropertyChanged<T>(ref T source, Expression<Func<T>> propertyExpression)
         {
-            if (propertyExpression == null) throw new ArgumentNullException("propertyExpression");
+            if (propertyExpression == null) throw new ArgumentNullException(nameof(propertyExpression));
 
             if (!(propertyExpression.Body is MemberExpression)) throw new NotSupportedException("このメソッドでは ()=>プロパティ の形式のラムダ式以外許可されません");
 

--- a/Livet.Shared/NotificationObject.cs
+++ b/Livet.Shared/NotificationObject.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
 using System.Threading;

--- a/Livet.Shared/ObservableSynchronizedCollection.cs
+++ b/Livet.Shared/ObservableSynchronizedCollection.cs
@@ -280,10 +280,7 @@ namespace Livet
         {
             var threadSafeHandler = Interlocked.CompareExchange(ref CollectionChanged, null, null);
 
-            if (threadSafeHandler != null)
-            {
-                threadSafeHandler(this, args);
-            }
+            threadSafeHandler?.Invoke(this, args);
         }
 
         /// <summary>
@@ -294,10 +291,7 @@ namespace Livet
         {
             var threadSafeHandler = Interlocked.CompareExchange(ref PropertyChanged, null, null);
 
-            if (threadSafeHandler != null)
-            {
-                threadSafeHandler(this, EventArgsFactory.GetPropertyChangedEventArgs(propertyName));
-            }
+            threadSafeHandler?.Invoke(this, EventArgsFactory.GetPropertyChangedEventArgs(propertyName));
         }
 
 

--- a/Livet.Shared/ObservableSynchronizedCollection.cs
+++ b/Livet.Shared/ObservableSynchronizedCollection.cs
@@ -36,7 +36,7 @@ namespace Livet
         /// <param name="source">初期値となるソース</param>
         public ObservableSynchronizedCollection(IEnumerable<T> source)
         {
-            if (source == null) throw new ArgumentNullException("source");
+            if (source == null) throw new ArgumentNullException(nameof(source));
             _list = new List<T>(source);
         }
 

--- a/Livet.Shared/ReadOnlyDispatcherCollection.cs
+++ b/Livet.Shared/ReadOnlyDispatcherCollection.cs
@@ -23,7 +23,7 @@ namespace Livet
 
         public ReadOnlyDispatcherCollection(DispatcherCollection<T> collection) : base(collection) 
         {
-            if (collection == null) throw new ArgumentNullException("collection");
+            if (collection == null) throw new ArgumentNullException(nameof(collection));
 
             _list = collection;
 

--- a/Livet.Shared/ReadOnlyDispatcherCollection.cs
+++ b/Livet.Shared/ReadOnlyDispatcherCollection.cs
@@ -23,9 +23,7 @@ namespace Livet
 
         public ReadOnlyDispatcherCollection(DispatcherCollection<T> collection) : base(collection) 
         {
-            if (collection == null) throw new ArgumentNullException(nameof(collection));
-
-            _list = collection;
+            _list = collection ?? throw new ArgumentNullException(nameof(collection));
 
             _listeners.Add(new PropertyChangedEventListener(_list,(sender, e) => OnPropertyChanged(e)));
             _listeners.Add(new CollectionChangedEventListener(_list,(sender,e) => OnCollectionChanged(e)));

--- a/Livet.Shared/ReadOnlyDispatcherCollection.cs
+++ b/Livet.Shared/ReadOnlyDispatcherCollection.cs
@@ -82,10 +82,7 @@ namespace Livet
             ThrowExceptionIfDisposed();
             var threadSafeHandler = Interlocked.CompareExchange(ref CollectionChanged, null, null);
 
-            if (threadSafeHandler != null)
-            {
-                threadSafeHandler(this, args);
-            }
+            threadSafeHandler?.Invoke(this, args);
         }
 
         protected void OnPropertyChanged(PropertyChangedEventArgs args)
@@ -93,10 +90,7 @@ namespace Livet
             ThrowExceptionIfDisposed();
             var threadSafeHandler = Interlocked.CompareExchange(ref PropertyChanged, null, null);
 
-            if (threadSafeHandler != null)
-            {
-                threadSafeHandler(this, args);
-            }
+            threadSafeHandler?.Invoke(this, args);
         }
 
         /// <summary>

--- a/Livet.Shared/ReadOnlyDispatcherCollection.cs
+++ b/Livet.Shared/ReadOnlyDispatcherCollection.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Collections.Specialized;

--- a/Livet.Shared/ViewModel.cs
+++ b/Livet.Shared/ViewModel.cs
@@ -71,10 +71,7 @@ namespace Livet
             if (_disposed) return;
             if (disposing)
             {
-                if (_compositeDisposable != null)
-                {
-                    _compositeDisposable.Dispose();
-                }
+                _compositeDisposable?.Dispose();
             }
             _disposed = true;
         }

--- a/Livet.Shared/ViewModelHelper.cs
+++ b/Livet.Shared/ViewModelHelper.cs
@@ -24,9 +24,9 @@ namespace Livet
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:DisposeObjectsBeforeLosingScope")]
         public static ReadOnlyDispatcherCollection<TViewModel> CreateReadOnlyDispatcherCollection<TModel, TViewModel>(IList<TModel> source, Func<TModel, TViewModel> converter, Dispatcher dispatcher)
         {
-            if (source == null) throw new ArgumentNullException("source");
-            if (converter == null) throw new ArgumentNullException("converter");
-            if (dispatcher == null) throw new ArgumentNullException("dispatcher");
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (converter == null) throw new ArgumentNullException(nameof(converter));
+            if (dispatcher == null) throw new ArgumentNullException(nameof(dispatcher));
 
             var sourceAsNotifyCollection = source as INotifyCollectionChanged;
             if (sourceAsNotifyCollection == null) throw new ArgumentException("sourceがINotifyCollectionChangedを実装していません");

--- a/Livet.Tests/Behaviors/MethodBinderTest.cs
+++ b/Livet.Tests/Behaviors/MethodBinderTest.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using Livet.Behaviors;
 using Livet.NUnit.TestInfrastructures;
 

--- a/Livet.Tests/Commands/CommandTest.cs
+++ b/Livet.Tests/Commands/CommandTest.cs
@@ -1,12 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using NUnit.Framework;
 using Livet.Commands;
 using System.Windows.Input;
 using System.Threading;
-using System.Diagnostics;
 
 namespace Livet.NUnit.Commands
 {

--- a/Livet.Tests/EventListeners/CollectionChangedEventListenerTest.cs
+++ b/Livet.Tests/EventListeners/CollectionChangedEventListenerTest.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Specialized;
 using System.Threading.Tasks;
 using NUnit.Framework;
-using Livet.NUnit;
 
 namespace Livet.NUnit.EventListeners
 {

--- a/Livet.Tests/EventListeners/CollectionChangedWeakEventListenerTest.cs
+++ b/Livet.Tests/EventListeners/CollectionChangedWeakEventListenerTest.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Livet.EventListeners.WeakEvents;
 using NUnit.Framework;

--- a/Livet.Tests/EventListeners/EventListenerTest.cs
+++ b/Livet.Tests/EventListeners/EventListenerTest.cs
@@ -1,7 +1,6 @@
 ﻿using Livet.EventListeners;
 using NUnit.Framework;
 using System;
-using Livet.NUnit;
 
 namespace Livet.NUnit.EventListeners
 {

--- a/Livet.Tests/EventListeners/LivetWeakEventListenerTest.cs
+++ b/Livet.Tests/EventListeners/LivetWeakEventListenerTest.cs
@@ -1,7 +1,6 @@
 ﻿using Livet.EventListeners.WeakEvents;
 using NUnit.Framework;
 using System;
-using Livet.NUnit;
 
 namespace Livet.NUnit.EventListeners
 {

--- a/Livet.Tests/EventListeners/PropertyChangedEventListenerTest.cs
+++ b/Livet.Tests/EventListeners/PropertyChangedEventListenerTest.cs
@@ -2,11 +2,7 @@
 using System;
 using System.ComponentModel;
 using System.Threading.Tasks;
-using System.Linq;
 using NUnit.Framework;
-using Livet.NUnit;
-using System.Collections.Concurrent;
-using System.Reflection;
 
 namespace Livet.NUnit.EventListeners
 {

--- a/Livet.Tests/EventListeners/PropertyChangedWeakEventListenerTest.cs
+++ b/Livet.Tests/EventListeners/PropertyChangedWeakEventListenerTest.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Livet.EventListeners.WeakEvents;
 using NUnit.Framework;

--- a/Livet.Tests/Messaging/MessageListenerTest.cs
+++ b/Livet.Tests/Messaging/MessageListenerTest.cs
@@ -1,9 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Threading;
 using NUnit.Framework;
 using Livet.Messaging;
 

--- a/Livet.Tests/NotificationObjectTest.cs
+++ b/Livet.Tests/NotificationObjectTest.cs
@@ -1,11 +1,6 @@
-﻿using Livet;
-using NUnit.Framework;
-using System;
+﻿using NUnit.Framework;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Livet.NUnit
 {

--- a/Livet.Tests/Properties/AssemblyInfo.cs
+++ b/Livet.Tests/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // アセンブリに関する一般情報は以下の属性セットをとおして制御されます。

--- a/Livet.Tests/TestInfrastructures/ChainingAssertion.NUnit.cs
+++ b/Livet.Tests/TestInfrastructures/ChainingAssertion.NUnit.cs
@@ -320,7 +320,7 @@ namespace NUnit.Framework
                     typeof(T).InvokeMember("Item", TransparentFlags | BindingFlags.SetProperty, null, target, indexes.Concat(new[] { value }).ToArray());
                     return true;
                 }
-                catch (MissingMethodException) { throw new ArgumentException(string.Format("indexer not found : Type <{0}>", typeof(T).Name)); };
+                catch (MissingMethodException) { throw new ArgumentException(string.Format("indexer not found : Type <{0}>", typeof(T).Name)); }
             }
 
             public override bool TryGetIndex(GetIndexBinder binder, object[] indexes, out object result)
@@ -330,7 +330,7 @@ namespace NUnit.Framework
                     result = typeof(T).InvokeMember("Item", TransparentFlags | BindingFlags.GetProperty, null, target, indexes);
                     return true;
                 }
-                catch (MissingMethodException) { throw new ArgumentException(string.Format("indexer not found : Type <{0}>", typeof(T).Name)); };
+                catch (MissingMethodException) { throw new ArgumentException(string.Format("indexer not found : Type <{0}>", typeof(T).Name)); }
             }
 
             public override bool TrySetMember(SetMemberBinder binder, object value)

--- a/Livet.Tests/TestInfrastructures/TestDispatcherContext.cs
+++ b/Livet.Tests/TestInfrastructures/TestDispatcherContext.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Windows.Threading;
 using System.Threading.Tasks;
 using System.Threading;

--- a/Livet.Tests/TestInfrastructures/TestEventPublisher.cs
+++ b/Livet.Tests/TestInfrastructures/TestEventPublisher.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.ComponentModel;
 using System.Collections.Specialized;
 

--- a/Livet.Tests/TestInfrastructures/TestViewModel.cs
+++ b/Livet.Tests/TestInfrastructures/TestViewModel.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Livet.NUnit.TestInfrastructures
 {

--- a/Livet.Tests/ViewModelHelperTest.cs
+++ b/Livet.Tests/ViewModelHelperTest.cs
@@ -1,16 +1,6 @@
-﻿using Livet;
-using System;
-using System.Linq;
-using System.Collections.Generic;
+﻿using System.Linq;
 using System.Windows.Threading;
 using System.Collections.ObjectModel;
-using System.Threading.Tasks;
-using System.Threading;
-using System.Text;
-using System.Windows;
-using System.Diagnostics;
-using System.IO;
-
 using NUnit.Framework;
 using Livet.NUnit.TestInfrastructures;
 

--- a/Livet/Properties/AssemblyInfo.cs
+++ b/Livet/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows.Markup;
 

--- a/LivetControlBindingSupportGenerator/MetaData.cs
+++ b/LivetControlBindingSupportGenerator/MetaData.cs
@@ -9,8 +9,6 @@
 // ------------------------------------------------------------------------------
 namespace LivetControlBindingSupportGenerator
 {
-    using System;
-    
     /// <summary>
     /// Class to produce the template output
     /// </summary>

--- a/LivetControlBindingSupportGenerator/MetaData.cs
+++ b/LivetControlBindingSupportGenerator/MetaData.cs
@@ -367,7 +367,7 @@ foreach(var generateTypeName in GeneratedTypeNames)
         {
             if ((indent == null))
             {
-                throw new global::System.ArgumentNullException("indent");
+                throw new global::System.ArgumentNullException(nameof(indent));
             }
             this.currentIndentField = (this.currentIndentField + indent);
             this.indentLengths.Add(indent.Length);
@@ -430,7 +430,7 @@ foreach(var generateTypeName in GeneratedTypeNames)
             {
                 if ((objectToConvert == null))
                 {
-                    throw new global::System.ArgumentNullException("objectToConvert");
+                    throw new global::System.ArgumentNullException(nameof(objectToConvert));
                 }
                 System.Type t = objectToConvert.GetType();
                 System.Reflection.MethodInfo method = t.GetMethod("ToString", new System.Type[] {

--- a/LivetControlBindingSupportGenerator/MetaData.partial.cs
+++ b/LivetControlBindingSupportGenerator/MetaData.partial.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace LivetControlBindingSupportGenerator
 {

--- a/LivetControlBindingSupportGenerator/Program.cs
+++ b/LivetControlBindingSupportGenerator/Program.cs
@@ -11,10 +11,8 @@ namespace LivetControlBindingSupportGenerator
     class Program
     {
 
-        private static Func<Type, bool> typeFilter = t => 
-        {
-            return t.IsSubclassOf(typeof(FrameworkElement)) && !t.IsAbstract && !t.IsGenericType && t.IsPublic;
-        };
+        private static Func<Type, bool> typeFilter =
+            t => t.IsSubclassOf(typeof(FrameworkElement)) && !t.IsAbstract && !t.IsGenericType && t.IsPublic;
 
         static void Main(string[] args)
         {
@@ -46,7 +44,7 @@ namespace LivetControlBindingSupportGenerator
                             return assemblyName;
                         }
                     )
-                ).Select(assemblyName => Assembly.Load(assemblyName))
+                ).Select(Assembly.Load)
                 .Select( a => { Console.WriteLine( a ); return a; } )
                 .ToArray();
 

--- a/LivetControlBindingSupportGenerator/Properties/AssemblyInfo.cs
+++ b/LivetControlBindingSupportGenerator/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // アセンブリに関する一般情報は以下の属性セットをとおして制御されます。

--- a/LivetControlBindingSupportGenerator/SetStateToControlBehavior.cs
+++ b/LivetControlBindingSupportGenerator/SetStateToControlBehavior.cs
@@ -466,7 +466,7 @@ foreach(var key in SetterHavingTargetProperties.Keys)
         {
             if ((indent == null))
             {
-                throw new global::System.ArgumentNullException("indent");
+                throw new global::System.ArgumentNullException(nameof(indent));
             }
             this.currentIndentField = (this.currentIndentField + indent);
             this.indentLengths.Add(indent.Length);
@@ -529,7 +529,7 @@ foreach(var key in SetterHavingTargetProperties.Keys)
             {
                 if ((objectToConvert == null))
                 {
-                    throw new global::System.ArgumentNullException("objectToConvert");
+                    throw new global::System.ArgumentNullException(nameof(objectToConvert));
                 }
                 System.Type t = objectToConvert.GetType();
                 System.Reflection.MethodInfo method = t.GetMethod("ToString", new System.Type[] {

--- a/LivetControlBindingSupportGenerator/SetStateToControlBehavior.cs
+++ b/LivetControlBindingSupportGenerator/SetStateToControlBehavior.cs
@@ -10,8 +10,7 @@
 namespace LivetControlBindingSupportGenerator
 {
     using System.Linq;
-    using System;
-    
+
     /// <summary>
     /// Class to produce the template output
     /// </summary>

--- a/LivetControlBindingSupportGenerator/SetStateToControlBehavior.partial.cs
+++ b/LivetControlBindingSupportGenerator/SetStateToControlBehavior.partial.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace LivetControlBindingSupportGenerator
 {

--- a/LivetControlBindingSupportGenerator/SetStateToSourceAction.cs
+++ b/LivetControlBindingSupportGenerator/SetStateToSourceAction.cs
@@ -10,8 +10,7 @@
 namespace LivetControlBindingSupportGenerator
 {
     using System.Linq;
-    using System;
-    
+
     /// <summary>
     /// Class to produce the template output
     /// </summary>

--- a/LivetControlBindingSupportGenerator/SetStateToSourceAction.cs
+++ b/LivetControlBindingSupportGenerator/SetStateToSourceAction.cs
@@ -433,7 +433,7 @@ foreach(var key in GetterHavingTargetProperties.Keys)
         {
             if ((indent == null))
             {
-                throw new global::System.ArgumentNullException("indent");
+                throw new global::System.ArgumentNullException(nameof(indent));
             }
             this.currentIndentField = (this.currentIndentField + indent);
             this.indentLengths.Add(indent.Length);
@@ -496,7 +496,7 @@ foreach(var key in GetterHavingTargetProperties.Keys)
             {
                 if ((objectToConvert == null))
                 {
-                    throw new global::System.ArgumentNullException("objectToConvert");
+                    throw new global::System.ArgumentNullException(nameof(objectToConvert));
                 }
                 System.Type t = objectToConvert.GetType();
                 System.Reflection.MethodInfo method = t.GetMethod("ToString", new System.Type[] {

--- a/LivetControlBindingSupportGenerator/SetStateToSourceAction.partial.cs
+++ b/LivetControlBindingSupportGenerator/SetStateToSourceAction.partial.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace LivetControlBindingSupportGenerator
 {

--- a/LivetControlBindingSupportGenerator/TypeInformation.cs
+++ b/LivetControlBindingSupportGenerator/TypeInformation.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Reflection;
 using System.Windows;
 

--- a/LivetEnumAndBooleanConverterGenerator/EnumToBooleanConverter.cs
+++ b/LivetEnumAndBooleanConverterGenerator/EnumToBooleanConverter.cs
@@ -543,7 +543,7 @@ foreach(var memberName in EnumMemberNames)
         {
             if ((indent == null))
             {
-                throw new global::System.ArgumentNullException("indent");
+                throw new global::System.ArgumentNullException(nameof(indent));
             }
             this.currentIndentField = (this.currentIndentField + indent);
             this.indentLengths.Add(indent.Length);
@@ -606,7 +606,7 @@ foreach(var memberName in EnumMemberNames)
             {
                 if ((objectToConvert == null))
                 {
-                    throw new global::System.ArgumentNullException("objectToConvert");
+                    throw new global::System.ArgumentNullException(nameof(objectToConvert));
                 }
                 System.Type t = objectToConvert.GetType();
                 System.Reflection.MethodInfo method = t.GetMethod("ToString", new System.Type[] {

--- a/LivetEnumAndBooleanConverterGenerator/EnumToBooleanConverter.cs
+++ b/LivetEnumAndBooleanConverterGenerator/EnumToBooleanConverter.cs
@@ -9,8 +9,6 @@
 // ------------------------------------------------------------------------------
 namespace LivetEnumAndBooleanConverterGenerator
 {
-    using System;
-    
     /// <summary>
     /// Class to produce the template output
     /// </summary>

--- a/LivetEnumAndBooleanConverterGenerator/EnumToBooleanConverter.partial.cs
+++ b/LivetEnumAndBooleanConverterGenerator/EnumToBooleanConverter.partial.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace LivetEnumAndBooleanConverterGenerator
 {

--- a/LivetEnumAndBooleanConverterGenerator/Program.cs
+++ b/LivetEnumAndBooleanConverterGenerator/Program.cs
@@ -25,7 +25,7 @@ namespace LivetEnumAndBooleanConverterGenerator
                     assemblyName.ProcessorArchitecture = ProcessorArchitecture.None;
                     return assemblyName;
                 }
-                ).Select(assemblyName => Assembly.Load(assemblyName))
+                ).Select(Assembly.Load)
                 .Select(a => { Console.WriteLine(a); return a; })
                 .ToArray();
 

--- a/LivetEnumAndBooleanConverterGenerator/Program.cs
+++ b/LivetEnumAndBooleanConverterGenerator/Program.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Windows;

--- a/LivetEnumAndBooleanConverterGenerator/Properties/AssemblyInfo.cs
+++ b/LivetEnumAndBooleanConverterGenerator/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // アセンブリに関する一般情報は以下の属性セットをとおして制御されます。

--- a/NuGet/LivetCask.nuspec
+++ b/NuGet/LivetCask.nuspec
@@ -11,7 +11,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>
       Livet is the infrastructure of MVVM pattern on WPF.
-      It supports .NET Framework 4.5.2 or lator, and licensed as zlib/libpng.
+      It supports .NET Framework 4.5.2 or later, and licensed as zlib/libpng.
     </description>
     <summary>WPF 4.5 MVVM Infrastructure.</summary>
     <copyright>Copyright (c) 2010-2019 Livet Project</copyright>

--- a/Samples/ViewLayerSupport/App.xaml.cs
+++ b/Samples/ViewLayerSupport/App.xaml.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Data;
-using System.Linq;
-using System.Windows;
+﻿using System.Windows;
 
 using Livet;
 

--- a/Samples/ViewLayerSupport/Models/Model.cs
+++ b/Samples/ViewLayerSupport/Models/Model.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-using Livet;
+﻿using Livet;
 
 namespace ViewLayerSupport.Models
 {

--- a/Samples/ViewLayerSupport/Properties/AssemblyInfo.cs
+++ b/Samples/ViewLayerSupport/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/Samples/ViewLayerSupport/ViewModels/LivetCallMethodActionWindowViewModel.cs
+++ b/Samples/ViewLayerSupport/ViewModels/LivetCallMethodActionWindowViewModel.cs
@@ -1,17 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.ComponentModel;
-
-using Livet;
-using Livet.Commands;
-using Livet.Messaging;
-using Livet.Messaging.IO;
-using Livet.EventListeners;
-using Livet.Messaging.Windows;
-
-using ViewLayerSupport.Models;
+﻿using Livet;
 
 namespace ViewLayerSupport.ViewModels
 {

--- a/Samples/ViewLayerSupport/ViewModels/MainWindowViewModel.cs
+++ b/Samples/ViewLayerSupport/ViewModels/MainWindowViewModel.cs
@@ -1,17 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.ComponentModel;
-
-using Livet;
-using Livet.Commands;
-using Livet.Messaging;
-using Livet.Messaging.IO;
-using Livet.EventListeners;
-using Livet.Messaging.Windows;
-
-using ViewLayerSupport.Models;
+﻿using Livet;
 
 namespace ViewLayerSupport.ViewModels
 {

--- a/Samples/ViewLayerSupport/ViewModels/MessagingWindowViewModel.cs
+++ b/Samples/ViewLayerSupport/ViewModels/MessagingWindowViewModel.cs
@@ -1,17 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.ComponentModel;
-
 using Livet;
-using Livet.Commands;
 using Livet.Messaging;
 using Livet.Messaging.IO;
-using Livet.EventListeners;
-using Livet.Messaging.Windows;
-
-using ViewLayerSupport.Models;
 using System.Windows;
 
 namespace ViewLayerSupport.ViewModels

--- a/Samples/ViewLayerSupport/ViewModels/PasswordBoxBindingSupportBehaviorWindowViewModel.cs
+++ b/Samples/ViewLayerSupport/ViewModels/PasswordBoxBindingSupportBehaviorWindowViewModel.cs
@@ -1,17 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.ComponentModel;
-
-using Livet;
-using Livet.Commands;
-using Livet.Messaging;
-using Livet.Messaging.IO;
-using Livet.EventListeners;
-using Livet.Messaging.Windows;
-
-using ViewLayerSupport.Models;
+﻿using Livet;
 
 namespace ViewLayerSupport.ViewModels
 {

--- a/Samples/ViewLayerSupport/ViewModels/SetStateToControlBehaviorWindowViewModel.cs
+++ b/Samples/ViewLayerSupport/ViewModels/SetStateToControlBehaviorWindowViewModel.cs
@@ -1,17 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.ComponentModel;
-
 using Livet;
-using Livet.Commands;
-using Livet.Messaging;
-using Livet.Messaging.IO;
-using Livet.EventListeners;
-using Livet.Messaging.Windows;
-
-using ViewLayerSupport.Models;
 
 namespace ViewLayerSupport.ViewModels
 {

--- a/Samples/ViewLayerSupport/ViewModels/SetStateToSourceActionWindowViewModel.cs
+++ b/Samples/ViewLayerSupport/ViewModels/SetStateToSourceActionWindowViewModel.cs
@@ -1,17 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.ComponentModel;
-
-using Livet;
-using Livet.Commands;
-using Livet.Messaging;
-using Livet.Messaging.IO;
-using Livet.EventListeners;
-using Livet.Messaging.Windows;
-
-using ViewLayerSupport.Models;
+﻿using Livet;
 
 namespace ViewLayerSupport.ViewModels
 {

--- a/Samples/ViewLayerSupport/ViewModels/TextBoxBindingSupportBehaviorWindowViewModel.cs
+++ b/Samples/ViewLayerSupport/ViewModels/TextBoxBindingSupportBehaviorWindowViewModel.cs
@@ -1,17 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.ComponentModel;
-
-using Livet;
-using Livet.Commands;
-using Livet.Messaging;
-using Livet.Messaging.IO;
-using Livet.EventListeners;
-using Livet.Messaging.Windows;
-
-using ViewLayerSupport.Models;
+﻿using Livet;
 
 namespace ViewLayerSupport.ViewModels
 {

--- a/Samples/ViewLayerSupport/Views/EnumToBooleanConverterWindow.xaml.cs
+++ b/Samples/ViewLayerSupport/Views/EnumToBooleanConverterWindow.xaml.cs
@@ -1,16 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows;
 
 namespace ViewLayerSupport.Views
 {

--- a/Samples/ViewLayerSupport/Views/LivetCallMethodActionWindow.xaml.cs
+++ b/Samples/ViewLayerSupport/Views/LivetCallMethodActionWindow.xaml.cs
@@ -1,16 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows;
 
 namespace ViewLayerSupport.Views
 {

--- a/Samples/ViewLayerSupport/Views/MainWindow.xaml.cs
+++ b/Samples/ViewLayerSupport/Views/MainWindow.xaml.cs
@@ -1,16 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows;
 
 namespace ViewLayerSupport.Views
 {

--- a/Samples/ViewLayerSupport/Views/MessagingWindow.xaml.cs
+++ b/Samples/ViewLayerSupport/Views/MessagingWindow.xaml.cs
@@ -1,16 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows;
 
 namespace ViewLayerSupport.Views
 {

--- a/Samples/ViewLayerSupport/Views/PasswordBoxBindingSupportBehaviorWindow.xaml.cs
+++ b/Samples/ViewLayerSupport/Views/PasswordBoxBindingSupportBehaviorWindow.xaml.cs
@@ -1,16 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows;
 
 namespace ViewLayerSupport.Views
 {

--- a/Samples/ViewLayerSupport/Views/SetStateToControlBehaviorWindow.xaml.cs
+++ b/Samples/ViewLayerSupport/Views/SetStateToControlBehaviorWindow.xaml.cs
@@ -1,16 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows;
 
 namespace ViewLayerSupport.Views
 {

--- a/Samples/ViewLayerSupport/Views/SetStateToSourceActionWindow.xaml.cs
+++ b/Samples/ViewLayerSupport/Views/SetStateToSourceActionWindow.xaml.cs
@@ -1,16 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows;
 
 namespace ViewLayerSupport.Views
 {

--- a/Samples/ViewLayerSupport/Views/TextBoxBindingSupportBehaviorWindow.xaml.cs
+++ b/Samples/ViewLayerSupport/Views/TextBoxBindingSupportBehaviorWindow.xaml.cs
@@ -1,16 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows;
 
 namespace ViewLayerSupport.Views
 {

--- a/Templates/ItemTemplates/Livet.ItemTemplateExtension/Properties/AssemblyInfo.cs
+++ b/Templates/ItemTemplates/Livet.ItemTemplateExtension/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/Templates/ItemTemplates/LivetInteractionMessageAction.CSharp/Properties/AssemblyInfo.cs
+++ b/Templates/ItemTemplates/LivetInteractionMessageAction.CSharp/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/Templates/ItemTemplates/LivetMessage.CSharp/Properties/AssemblyInfo.cs
+++ b/Templates/ItemTemplates/LivetMessage.CSharp/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/Templates/ItemTemplates/LivetModel.CSharp/Properties/AssemblyInfo.cs
+++ b/Templates/ItemTemplates/LivetModel.CSharp/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/Templates/ItemTemplates/LivetViewModel.CSharp/Properties/AssemblyInfo.cs
+++ b/Templates/ItemTemplates/LivetViewModel.CSharp/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/Templates/ItemTemplates/LivetWindow.CSharp/Properties/AssemblyInfo.cs
+++ b/Templates/ItemTemplates/LivetWindow.CSharp/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/Templates/ItemTemplates/LivetWindow.CSharp/Window.xaml
+++ b/Templates/ItemTemplates/LivetWindow.CSharp/Window.xaml
@@ -23,7 +23,7 @@
             <l:DataContextDisposeAction/>
         </i:EventTrigger>
 
-        <!-- If you make user choose 'OK or Cancel' closing Window, then please use Window Close nacel Behavior. -->
+        <!-- If you make user choose 'OK or Cancel' closing Window, then please use Window Close cancel Behavior. -->
 
     </i:Interaction.Triggers>
 

--- a/Templates/Livet.Extensibility/Properties/AssemblyInfo.cs
+++ b/Templates/Livet.Extensibility/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/Templates/Livet.ProjectTemplate.CSharp.NETCore/Properties/AssemblyInfo.cs
+++ b/Templates/Livet.ProjectTemplate.CSharp.NETCore/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/Templates/Livet.ProjectTemplate.CSharp.NETCore/Views/MainWindow.xaml
+++ b/Templates/Livet.ProjectTemplate.CSharp.NETCore/Views/MainWindow.xaml
@@ -1,33 +1,34 @@
-﻿<Window x:Class="$safeprojectname$.Views.MainWindow"
-        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
-        xmlns:ei="http://schemas.microsoft.com/expression/2010/interactions"
-        xmlns:l="http://schemas.livet-mvvm.net/2011/wpf"
-        xmlns:v="clr-namespace:$safeprojectname$.Views"
-        xmlns:vm="clr-namespace:$safeprojectname$.ViewModels"
-        Title="MainWindow" Height="350" Width="525">
-    
+﻿<Window
+    x:Class="$safeprojectname$.Views.MainWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ei="http://schemas.microsoft.com/expression/2010/interactions"
+    xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+    xmlns:l="http://schemas.livet-mvvm.net/2011/wpf"
+    xmlns:v="clr-namespace:$safeprojectname$.Views"
+    xmlns:vm="clr-namespace:$safeprojectname$.ViewModels"
+    Title="MainWindow"
+    Width="525"
+    Height="350">
+
     <Window.DataContext>
-        <vm:MainWindowViewModel/>
+        <vm:MainWindowViewModel />
     </Window.DataContext>
 
     <i:Interaction.Triggers>
-        <!-- When ContentRendered event raised, Initialize method of ViewModel would be called. -->
+        <!--  When ContentRendered event raised, Initialize method of ViewModel would be called.  -->
         <i:EventTrigger EventName="ContentRendered">
-            <l:LivetCallMethodAction MethodTarget="{Binding}" MethodName="Initialize"/>
+            <l:LivetCallMethodAction MethodName="Initialize" MethodTarget="{Binding}" />
         </i:EventTrigger>
 
-        <!-- Dispose method is called, when Window closing. -->
+        <!--  Dispose method is called, when Window closing.  -->
         <i:EventTrigger EventName="Closed">
-            <l:DataContextDisposeAction/>
+            <l:DataContextDisposeAction />
         </i:EventTrigger>
 
-        <!-- If you make user choose 'OK or Cancel' closing Window, then please use Window Close nacel Behavior. -->
+        <!--  If you make user choose 'OK or Cancel' closing Window, then please use Window Close cancel Behavior.  -->
 
     </i:Interaction.Triggers>
 
-    <Grid>
-        
-    </Grid>
+    <Grid />
 </Window>

--- a/Templates/Livet.ProjectTemplate.CSharp/Properties/AssemblyInfo.cs
+++ b/Templates/Livet.ProjectTemplate.CSharp/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/Templates/Livet.ProjectTemplate.CSharp/Views/MainWindow.xaml
+++ b/Templates/Livet.ProjectTemplate.CSharp/Views/MainWindow.xaml
@@ -1,33 +1,34 @@
-﻿<Window x:Class="$safeprojectname$.Views.MainWindow"
-        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
-        xmlns:ei="http://schemas.microsoft.com/expression/2010/interactions"
-        xmlns:l="http://schemas.livet-mvvm.net/2011/wpf"
-        xmlns:v="clr-namespace:$safeprojectname$.Views"
-        xmlns:vm="clr-namespace:$safeprojectname$.ViewModels"
-        Title="MainWindow" Height="350" Width="525">
-    
+﻿<Window
+    x:Class="$safeprojectname$.Views.MainWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ei="http://schemas.microsoft.com/expression/2010/interactions"
+    xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+    xmlns:l="http://schemas.livet-mvvm.net/2011/wpf"
+    xmlns:v="clr-namespace:$safeprojectname$.Views"
+    xmlns:vm="clr-namespace:$safeprojectname$.ViewModels"
+    Title="MainWindow"
+    Width="525"
+    Height="350">
+
     <Window.DataContext>
-        <vm:MainWindowViewModel/>
+        <vm:MainWindowViewModel />
     </Window.DataContext>
-    
+
     <i:Interaction.Triggers>
-        <!-- When ContentRendered event raised, Initialize method of ViewModel would be called. -->
+        <!--  When ContentRendered event raised, Initialize method of ViewModel would be called.  -->
         <i:EventTrigger EventName="ContentRendered">
-            <l:LivetCallMethodAction MethodTarget="{Binding}" MethodName="Initialize"/>
+            <l:LivetCallMethodAction MethodName="Initialize" MethodTarget="{Binding}" />
         </i:EventTrigger>
 
-        <!-- Dispose method is called, when Window closing. -->
+        <!--  Dispose method is called, when Window closing.  -->
         <i:EventTrigger EventName="Closed">
-            <l:DataContextDisposeAction/>
+            <l:DataContextDisposeAction />
         </i:EventTrigger>
 
-        <!-- If you make user choose 'OK or Cancel' closing Window, then please use Window Close nacel Behavior. -->
+        <!--  If you make user choose 'OK or Cancel' closing Window, then please use Window Close cancel Behavior.  -->
 
     </i:Interaction.Triggers>
-    
-    <Grid>
-        
-    </Grid>
+
+    <Grid />
 </Window>


### PR DESCRIPTION
以下の内容が含まれます。破壊的な変更を含まないよう気をつけています。

 - 全く不要な部分の削除
 - 不要な`using`ディレクティブの削除
 - `sealed`クラス内の不必要な`sealed`キーワードを削除
 - メンバー呼び出しに`this.`を付けているところと付けていないところが混ざっていたので，付けない方に統一
 - タイポ（マークアップ内）の修正
 - C# 6.0, C# 7.0で導入された機能を使用して記述を簡素化（`nameof`, `?.`, `??`）

